### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol (MCP) server for integrating Tavily's search
 API with LLMs. This server provides intelligent web search
 capabilities optimized for high-quality, factual results.
 
+<a href="https://glama.ai/mcp/servers/1jcttrux58"><img width="380" height="200" src="https://glama.ai/mcp/servers/1jcttrux58/badge" alt="Tavily Search Server MCP server" /></a>
+
 ## Features
 
 - 🔍 Advanced web search capabilities through Tavily API


### PR DESCRIPTION
This PR adds a badge for the [MCP Tavily Search Server](https://glama.ai/mcp/servers/1jcttrux58) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1jcttrux58"><img width="380" height="200" src="https://glama.ai/mcp/servers/1jcttrux58/badge" alt="Tavily Search Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.